### PR TITLE
Add support for controller within a module

### DIFF
--- a/lib/oink/reports/active_record_instantiation_report.rb
+++ b/lib/oink/reports/active_record_instantiation_report.rb
@@ -26,7 +26,7 @@ module Oink
               @pids[pid][:buffer] << line
             end
 
-            if line =~ /Oink Action: ((\w+)#(\w+))/
+            if line =~ /Oink Action: (([\w\/]+)#(\w+))/
 
               @pids[pid][:action] = $1
               unless @pids[pid][:request_finished]

--- a/lib/oink/reports/memory_usage_report.rb
+++ b/lib/oink/reports/memory_usage_report.rb
@@ -25,7 +25,7 @@ module Oink
               @pids[pid][:buffer] << line
             end
 
-            if line =~ /Oink Action: ((\w+)#(\w+))/
+            if line =~ /Oink Action: (([\w\/]+)#(\w+))/
 
               unless @pids[pid][:request_finished]
                 @pids[pid][:last_memory_reading] = -1

--- a/spec/oink/middleware_spec.rb
+++ b/spec/oink/middleware_spec.rb
@@ -46,6 +46,11 @@ describe Oink::Middleware do
       get "/no_pigs", {}, {'action_dispatch.request.parameters' => {'controller' => 'oinkoink', 'action' => 'piggie'}}
       log_output.string.should include("Oink Action: oinkoink#piggie")
     end
+
+    it "logs the action and controller within a module" do
+      get "/no_pigs", {}, {'action_dispatch.request.parameters' => {'controller' => 'oinkoink/admin', 'action' => 'piggie'}}
+      log_output.string.should include("Oink Action: oinkoink/admin#piggie")
+    end
   end
 
   it "reports 0 totals" do


### PR DESCRIPTION
Oink does not reports the correct controller if it's inside a module, like the example below:

``` ruby
class Report::PaymentsController < ApplicationController
  def show
    ...
  end
end
```

`MemoryUsageReport#print` and `ActiveRecordInstantiationReport#print` should parse it as `"report/payments#show"`
