### PR TITLE
Add support for an averaged output

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -115,6 +115,16 @@ e.g. To find all actions which increase the heap size more than 75 MB, where log
   1, PublicPagesController#join
   1, CommentsController#create
 
+  Aggregated Totals:
+  Action                                  Max     Mean    Min     Total   Number of requests
+  SportsController#show                   101560  19754   4       5590540 283
+  CommentsController#create               8344    701     4       253324  361
+  ColorSchemesController#show             10124   739     4       68756   93
+  PublicPagesController#join              9004    1346    8       51172   38
+  DashboardsController#show               13696   2047    8       45036   22
+  SessionsController#create               9220    528     8       17448   33
+  GroupsController#show                   10748   1314    8       15776   12
+
 e.g. In verbose mode, oink will print out all the log information from your logs about the actions which exceeded the threshold specified
 
   $ oink --format verbose --threshold=75 /tmp/logs/*

--- a/lib/oink/reports/base.rb
+++ b/lib/oink/reports/base.rb
@@ -13,6 +13,7 @@ module Oink
 
         @pids = {}
         @bad_actions = {}
+        @bad_actions_averaged = {}
         @bad_requests = PriorityQueue.new(10)
       end
 
@@ -32,6 +33,25 @@ module Oink
         @bad_actions.sort{|a,b| b[1]<=>a[1]}.each { |elem|
           output.puts "#{elem[1]}, #{elem[0]}"
         }
+        output.puts "\nAggregated Totals:\n"
+        if @bad_actions_averaged.length > 0
+          action_stats =  @bad_actions_averaged.map { |action,values|
+            total = values.inject(0){ |sum,x| sum+x }
+            {
+              :action => action,
+              :total => total,
+              :mean => total/values.length,
+              :max => values.max,
+              :min => values.min,
+              :count => values.length,
+            }
+          }
+          action_width = @bad_actions_averaged.keys.map{|k| k.length}.max
+          output.puts "#{'Action'.ljust(action_width)}\tMax\tMean\tMin\tTotal\tNumber of requests"
+          action_stats.sort{|a,b| b[:total]<=>a[:total]}.each do |action_stat|
+            output.puts "#{action_stat[:action].ljust(action_width)}\t#{action_stat[:max]}\t#{action_stat[:mean]}\t#{action_stat[:min]}\t#{action_stat[:total]}\t#{action_stat[:count]}"
+          end
+        end
       end
     end
   end

--- a/lib/oink/reports/memory_usage_report.rb
+++ b/lib/oink/reports/memory_usage_report.rb
@@ -52,6 +52,8 @@ module Oink
                     @pids[pid][:buffer].each { |b| output.puts b }
                     output.puts "---------------------------------------------------------------------"
                   end
+                  @bad_actions_averaged[@pids[pid][:action]] ||= []
+                  @bad_actions_averaged[@pids[pid][:action]] << memory_diff
                 end
               end
 

--- a/spec/oink/reports/active_record_instantiation_report_spec.rb
+++ b/spec/oink/reports/active_record_instantiation_report_spec.rb
@@ -63,8 +63,8 @@ module Oink::Reports
         io = StringIO.new(str)
         output = PsuedoOutput.new
         ActiveRecordInstantiationReport.new(io, 50).print(output)
-        output[-2].should == "2, Media#show"
-        output[-1].should == "1, Users#show"
+        output[8].should == "2, Media#show"
+        output[9].should == "1, Users#show"
       end
 
       it "should not be bothered by incomplete requests" do


### PR DESCRIPTION
This pull request adds support for an aggregated display of the memory usage which is helpful for not just finding which action is responsible for the largest increases, but which action is responsible for the most total memory increase. It adds a section that looks like this:

```
  Aggregated Totals:
  Action                                  Max     Mean    Min     Total   Number of requests
  SportsController#show                   101560  19754   4       5590540 283
  CommentsController#create               8344    701     4       253324  361
  ColorSchemesController#show             10124   739     4       68756   93
  PublicPagesController#join              9004    1346    8       51172   38
  DashboardsController#show               13696   2047    8       45036   22
  SessionsController#create               9220    528     8       17448   33
  GroupsController#show                   10748   1314    8       15776   12
```
