### PR TITLE
Fix Hash Sort Exception

### DIFF
--- a/lib/oink/instrumentation/active_record.rb
+++ b/lib/oink/instrumentation/active_record.rb
@@ -32,7 +32,7 @@ module Oink
           end
 
           def self.instantiated_hash
-            Thread.current['oink.activerecord.instantiations']
+            Thread.current['oink.activerecord.instantiations'] || {}
           end
 
           def self.instantiated_hash=(hsh)


### PR DESCRIPTION
I started getting this on image requests where ActiveRecord is not loaded.

NoMethodError (undefined method `sort' for nil:NilClass):
  oink (0.10.0) lib/oink/utils/hash_utils.rb:5:in`to_sorted_array'
  oink (0.10.0) lib/oink/middleware.rb:48:in `log_activerecord'
  oink (0.10.0) lib/oink/middleware.rb:21:in`call'
  warden (1.2.1) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.1) lib/warden/manager.rb:34:in`catch'
  warden (1.2.1) lib/warden/manager.rb:34:in `call'
  actionpack (3.2.1) lib/action_dispatch/middleware/best_standards_support.rb:17:in`call'
  rack (1.4.1) lib/rack/etag.rb:23:in `call'
  rack (1.4.1) lib/rack/conditionalget.rb:25:in`call'
  actionpack (3.2.1) lib/action_dispatch/middleware/head.rb:14:in `call'
  remotipart (1.0.2) lib/remotipart/middleware.rb:30:in`call'
  actionpack (3.2.1) lib/action_dispatch/middleware/params_parser.rb:21:in `call'
  actionpack (3.2.1) lib/action_dispatch/middleware/flash.rb:242:in`call'
  rack (1.4.1) lib/rack/session/abstract/id.rb:205:in `context'
  rack (1.4.1) lib/rack/session/abstract/id.rb:200:in`call'
  rack-p3p (0.5.0) lib/rack-p3p.rb:11:in `call'
  actionpack (3.2.1) lib/action_dispatch/middleware/cookies.rb:338:in`call'
  activerecord (3.2.1) lib/active_record/query_cache.rb:64:in `call'
  activerecord (3.2.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:443:in`call'
  actionpack (3.2.1) lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  activesupport (3.2.1) lib/active_support/callbacks.rb:405:in`_run__4079966539919658034__call__3128255809264830011__callbacks'
  activesupport (3.2.1) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.1) lib/active_support/callbacks.rb:385:in`_run_call_callbacks'
  activesupport (3.2.1) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.1) lib/action_dispatch/middleware/callbacks.rb:27:in`call'
  actionpack (3.2.1) lib/action_dispatch/middleware/reloader.rb:65:in `call'
  actionpack (3.2.1) lib/action_dispatch/middleware/remote_ip.rb:31:in`call'
  actionpack (3.2.1) lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
  actionpack (3.2.1) lib/action_dispatch/middleware/show_exceptions.rb:56:in`call'
  railties (3.2.1) lib/rails/rack/logger.rb:26:in `call_app'
  railties (3.2.1) lib/rails/rack/logger.rb:16:in`call'
  actionpack (3.2.1) lib/action_dispatch/middleware/request_id.rb:22:in `call'
  rack (1.4.1) lib/rack/methodoverride.rb:21:in`call'
  rack (1.4.1) lib/rack/runtime.rb:17:in `call'
  activesupport (3.2.1) lib/active_support/cache/strategy/local_cache.rb:72:in`call'
  rack (1.4.1) lib/rack/lock.rb:15:in `call'
  railties (3.2.1) lib/rails/engine.rb:479:in`call'
  railties (3.2.1) lib/rails/application.rb:220:in `call'
  railties (3.2.1) lib/rails/railtie/configurable.rb:30:in`method_missing'
  rack (1.4.1) lib/rack/deflater.rb:13:in `call'
  rack (1.4.1) lib/rack/content_length.rb:14:in`call'
  railties (3.2.1) lib/rails/rack/log_tailer.rb:14:in `call'
  rack (1.4.1) lib/rack/handler/webrick.rb:59:in`service'
  /Users/gabe/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/webrick/httpserver.rb:138:in `service'
  /Users/gabe/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/webrick/httpserver.rb:94:in`run'
  /Users/gabe/.rvm/rubies/ruby-1.9.3-p125/lib/ruby/1.9.1/webrick/server.rb:191:in `block in start_thread'
