### PR TITLE
Check for exit status immediately after running command

### DIFF
--- a/lib/oink/instrumentation/memory_snapshot.rb
+++ b/lib/oink/instrumentation/memory_snapshot.rb
@@ -97,6 +97,7 @@ module Oink
 
       def initialize(cmd)
         @stdout = `#{cmd}`
+        @process_status = $?
       end
 
       def self.execute(cmd)
@@ -108,7 +109,7 @@ module Oink
       end
 
       def success?
-        $?.success?
+        @process_status.success?
       end
 
     end


### PR DESCRIPTION
Just drive-by editing, thought it made more sense to collect the
exit status immediately when the cmd is run to avoid potential
TOCTOU bugs http://en.wikipedia.org/wiki/Time-of-check-to-time-of-use
(although it still doesn't guarantee the elimination)
