### PR TITLE
add optional config variable path to use request path instead of controller action

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -54,6 +54,10 @@ You can also initialize it with an optional logger instance enabling your applic
 
 (This setup enables Oink to work with Request Log Analyzer (https://github.com/wvanbergen/request-log-analyzer), which currently parses rails logs)
 
+You can also initialize it with an optional boolean path variable enabling Oink to log entries with the request path info(env['PATH_INFO']) instead of the controller/action:
+
+  Rails.application.middleware.use( Oink::Middleware, :path => true )
+
 Oink::Middleware logs memory and activerecord usage by default.
 
 You can configure which using the :instruments option. For memory only:

--- a/lib/oink/reports/active_record_instantiation_report.rb
+++ b/lib/oink/reports/active_record_instantiation_report.rb
@@ -26,9 +26,9 @@ module Oink
               @pids[pid][:buffer] << line
             end
 
-            if line =~ /Oink Action: (([\w\/]+)#(\w+))/
+            if line =~ /Oink (Action|Path): (.*)/
 
-              @pids[pid][:action] = $1
+              @pids[pid][:action] = $2
               unless @pids[pid][:request_finished]
                 @pids[pid][:buffer] = [line]
               end

--- a/lib/oink/reports/memory_usage_report.rb
+++ b/lib/oink/reports/memory_usage_report.rb
@@ -25,12 +25,12 @@ module Oink
               @pids[pid][:buffer] << line
             end
 
-            if line =~ /Oink Action: (([\w\/]+)#(\w+))/
+            if line =~ /Oink (Action|Path): (.*)/
 
               unless @pids[pid][:request_finished]
                 @pids[pid][:last_memory_reading] = -1
               end
-              @pids[pid][:action] = $1
+              @pids[pid][:action] = $2
               @pids[pid][:request_finished] = false
 
             elsif line =~ /Memory usage: (\d+) /

--- a/spec/oink/middleware_configuration_spec.rb
+++ b/spec/oink/middleware_configuration_spec.rb
@@ -61,5 +61,20 @@ describe "Oink::Middleware configuration" do
         @log_output.string.should include("Instantiation Breakdown:")
       end
     end
+
+    context "with the path set to true" do
+      before do
+        @oink_configuration = { :path => true }
+        get "/no_pigs", {}, {'action_dispatch.request.parameters' => {'controller' => 'oinkoink', 'action' => 'piggie'}}
+      end
+
+      it "logs the path " do
+        @log_output.string.should include("Oink Path: /no_pigs")
+      end
+
+      it "does not log the action and controller " do
+        @log_output.string.should_not include("Oink Action:")
+      end
+    end
   end
 end


### PR DESCRIPTION
This pr adds an optional config variable `path` that is boolean so that instead of logging requests `controller#action`, you can specify that you want to log `ENV['PATH_INFO']` instead.

So you just do `Rails.application.middleware.use( Oink::Middleware, :path => true )` and then oink will log `"Oink Path: /no_pigs"` instead of `"Oink Action: oinkoink#piggie"`

Thanks
