### PR TITLE
Support for latest hodel_3000_compilant_logger output

### DIFF
--- a/lib/oink/reports/memory_usage_report.rb
+++ b/lib/oink/reports/memory_usage_report.rb
@@ -19,7 +19,7 @@ module Oink
              # Skip this line since we're only interested in the Hodel 3000 compliant lines
             next unless line =~ HODEL_LOG_FORMAT_REGEX
 
-            if line =~ /rails\[(\d+)\]/
+            if line =~ /rails\[([\d:]+)\]/
               pid = $1
               @pids[pid] ||= { :buffer => [], :last_memory_reading => -1, :current_memory_reading => -1, :action => "", :request_finished => true }
               @pids[pid][:buffer] << line


### PR DESCRIPTION
With this [change](https://github.com/topfunky/hodel_3000_compliant_logger/commit/7e16fb98f390c621bef30ece358804f707338277), I needed to expect ":" in the PID regex.
