### PR TITLE
Allow logging of specified environment variables.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -64,6 +64,10 @@ For activerecord instantiation counts only:
 
   Rails.application.middleware.use( Oink::Middleware, :instruments => :activerecord )
 
+Environment variables can also be logged by specifying `env_vars`. This is especially handy for displaying request ID or REQUEST_URI from the Rails `env` object.
+
+  Rails.application.middleware.use( Oink::Middleware, :env_vars => ['action_dispatch.request_id', 'REQUEST_ID'] )
+
 Note that the previous way of configuring oink, as a set of modules to include into rails controllers, is deprecated.
 
 == Analyzing logs

--- a/lib/oink/middleware.rb
+++ b/lib/oink/middleware.rb
@@ -40,10 +40,11 @@ module Oink
 
     def log_environment(env)
       return if @env_vars.empty?
-      env_message = @env_vars.map { |key|
+      env_message = @env_vars.map do |key|
         value = env[key]
-        "#{key.inspect}: #{value.inspect if value && value.respond_to?(:inspect)}"
-      }.join(', ')
+        display_value = value.inspect if value && value.respond_to?(:inspect)
+        "#{key.inspect}: #{display_value}"
+      end.join(', ')
       @logger.info("Environment: {#{env_message}}")
     end
 

--- a/lib/oink/middleware.rb
+++ b/lib/oink/middleware.rb
@@ -9,6 +9,7 @@ module Oink
       @app         = app
       @logger      = options[:logger] || Hodel3000CompliantLogger.new("log/oink.log")
       @instruments = options[:instruments] ? Array(options[:instruments]) : [:memory, :activerecord]
+      @env_vars    = options[:env_vars] ? Array(options[:env_vars]) : []
 
       Oink.extend_active_record! if @instruments.include?(:activerecord)
     end
@@ -17,6 +18,7 @@ module Oink
       status, headers, body = @app.call(env)
 
       log_routing(env)
+      log_environment(env)
       log_memory
       log_activerecord
       log_completed
@@ -34,6 +36,15 @@ module Oink
         action     = routing_info['action']
         @logger.info("Oink Action: #{controller}##{action}")
       end
+    end
+
+    def log_environment(env)
+      return if @env_vars.empty?
+      env_message = @env_vars.map { |key|
+        value = env[key]
+        "#{key.inspect}: #{value.inspect if value && value.respond_to?(:inspect)}"
+      }.join(', ')
+      @logger.info("Environment: {#{env_message}}")
     end
 
     def log_memory

--- a/spec/oink/middleware_spec.rb
+++ b/spec/oink/middleware_spec.rb
@@ -58,6 +58,17 @@ describe Oink::Middleware do
     end
   end
 
+  context "include specified environment variables in the oink log" do
+    let(:app) do
+      Oink::Middleware.new(SampleApplication.new, :logger => logger, :env_vars => ['action_dispatch.request_id'])
+    end
+
+    it "includes specified environment variables" do
+      get "/no_pigs", {}, {"action_dispatch.request_id" => "4cc822f8-0d85-4d80-bcae-d94a4567e06c"}
+      log_output.string.should include('Environment: {"action_dispatch.request_id": "4cc822f8-0d85-4d80-bcae-d94a4567e06c"}')
+    end
+  end
+
   it "reports 0 totals" do
     get "/no_pigs"
     log_output.string.should include("Instantiation Breakdown: Total: 0")


### PR DESCRIPTION
This PR allows users to log extra environment information to the oink.log, if environment keys are specified.

If an optional `env_vars` array is passed to the middleware, the logs will have an additional `Environment:` line with specified environment keys and values:
```ruby
Rails.application.middleware.use( Oink::Middleware, env_vars: ['action_dispatch.request_id'] )
```
```
Jan 29 18:28:39 vocalhost rails[74025]: Oink Action: home#show
Jan 29 18:28:39 vocalhost rails[74025]: Environment: {"action_dispatch.request_id": "4cc822f8-0d85-4d80-bcae-d94a4567e06c"}
Jan 29 18:28:39 vocalhost rails[74025]: Memory usage: 4825792 | PID: 74025
Jan 29 18:28:39 vocalhost rails[74025]: Instantiation Breakdown: Total: 2 | Page: 1 | User: 1
Jan 29 18:28:39 vocalhost rails[74025]: Oink Log Entry Complete
```

This is especially useful for logging the request ID, since logs may be distributed among multiple app servers, and timestamps don't always line up exactly.